### PR TITLE
Add debugging option for ROS launch files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
 				"twxs.cmake",
 				"yzhang.markdown-all-in-one",
 				"zachflower.uncrustify",
-				"betwo.b2-catkin-tools"
+				"betwo.b2-catkin-tools",
+				"ms-iot.vscode-ros"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,8 +28,10 @@
 		"vscode": {
 			"extensions": [
 				"althack.ament-task-provider",
+				"betwo.b2-catkin-tools",
 				"DotJoshJohnson.xml",
 				"ms-azuretools.vscode-docker",
+				"ms-iot.vscode-ros",
 				"ms-python.python",
 				"ms-vscode.cpptools",
 				"redhat.vscode-yaml",
@@ -37,9 +39,7 @@
 				"streetsidesoftware.code-spell-checker",
 				"twxs.cmake",
 				"yzhang.markdown-all-in-one",
-				"zachflower.uncrustify",
-				"betwo.b2-catkin-tools",
-				"ms-iot.vscode-ros"
+				"zachflower.uncrustify"
 			]
 		}
 	}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,7 +50,15 @@
           "ignoreFailures": true
         }
       ]
-    }
+    },
+    //Example of a ROS Launch file
+    {
+      "name": "ROS: Launch File",
+      "type": "ros",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "target": "${workspaceFolder}/install/share/${input:package}/launch/${input:ros_launch}",
+    },
   ],
   "inputs": [
     {
@@ -64,6 +72,12 @@
       "type": "promptString",
       "description": "Program name",
       "default": "publisher_member_function"
+    },
+    {
+      "id": "ros_launch",
+      "type": "promptString",
+      "description": "ROS launch name",
+      "default": "file_name_launch.py"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,11 +53,18 @@
     },
     //Example of a ROS Launch file
     {
-      "name": "ROS: Launch File",
+      "name": "ROS: Launch File (merge-install)",
       "type": "ros",
       "request": "launch",
       "preLaunchTask": "build",
       "target": "${workspaceFolder}/install/share/${input:package}/launch/${input:ros_launch}",
+    },
+    {
+      "name": "ROS: Launch File (isolated-install)",
+      "type": "ros",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "target": "${workspaceFolder}/install/${input:package}/share/${input:package}/launch/${input:ros_launch}",
     },
   ],
   "inputs": [

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Take a look at [how I develop using tasks](https://www.allisonthackston.com/arti
 
 ### Debugging
 
-This template sets up debugging for python files and gdb for cpp programs.  See [`.vscode/launch.json`](.vscode/launch.json) for configuration details.
+This template sets up debugging for python files, gdb for cpp programs and ROS launch files.  See [`.vscode/launch.json`](.vscode/launch.json) for configuration details.
 
 ### Continuous Integration
 


### PR DESCRIPTION
Thanks @athackst for this template, it made my workflow much more efficient!

I wanted to contribute to this repository by adding the ability to debug ROS launch files directly. Sometimes you need to debug a node (or several) that receives a lot of configuration parameters from a launch file and [parsing them manually](https://github.com/athackst/vscode_ros2_workspace/issues/10#issuecomment-946364080) might not be the best solution.

This uses the official Microsoft ROS extension for VS Code ([ms-iot.vscode-ros](https://marketplace.visualstudio.com/items?itemName=ms-iot.vscode-ros)). More info [here](https://marketplace.visualstudio.com/items?itemName=ms-iot.vscode-ros).

![launch-and-debug-nodes](https://github.com/ms-iot/vscode-ros/raw/master/media/documentation/debug-support/launch-and-debug-nodes.gif)

