### PR TITLE
Add script to add submodules to workspace from repos file

### DIFF
--- a/.devcontainer/repos_to_submodules.py
+++ b/.devcontainer/repos_to_submodules.py
@@ -1,0 +1,38 @@
+import glob
+import os
+import subprocess
+import yaml
+
+prefix="src"
+
+def add_git_submodule(repo_name, repo_url, repo_version):
+    subprocess.call(['git', 'submodule', 'add', '-b', repo_version, repo_url, repo_name])
+
+def is_submodule(repo_name):
+    try:
+        subprocess.check_output(['git', 'submodule', 'status', repo_name], stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        return False 
+
+def parse_repos_file(file_path):
+    with open(file_path, 'r') as file:
+        repos_data = yaml.safe_load(file)
+        repositories = repos_data['repositories']
+        
+        for repo_name, repo_info in repositories.items():
+            if 'type' in repo_info and repo_info['type'] == 'git':
+                repo_url = repo_info['url']
+                repo_version = repo_info['version']
+                submodule_name = os.path.join(prefix, repo_name)
+
+                if not is_submodule(submodule_name):
+                    add_git_submodule(submodule_name, repo_url, repo_version)
+                    print(f"Added {repo_name} as a submodule.")
+
+# Find .repos files within the src directory
+repos_files = glob.glob('src/**/*.repos', recursive=True)
+
+# Process each .repos file
+for repos_file in repos_files:
+    parse_repos_file(repos_file)

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -228,6 +228,13 @@
             "type": "shell",
             "command": "./setup.sh",
             "problemMatcher": []
+        },
+        {
+            "label": "add submodules from .repos",
+            "detail": "Create a git submodule for all repositories in your .repos file",
+            "type": "shell",
+            "command": "python3 .devcontainer/repos_to_submodules.py",
+            "problemMatcher": []
         }
     ],
     "inputs": [

--- a/README.md
+++ b/README.md
@@ -143,3 +143,26 @@ If you want to access the vGPU through WSL2, you'll need to add additional compo
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},
 ```
+
+### Repos are not showing up in VS Code source control
+
+This is likely because vscode doesn't necessarily know about other repositories unless you've added them directly. 
+
+```
+File->Add Folder To Workspace
+```
+
+![Screenshot-26](https://github.com/athackst/vscode_ros2_workspace/assets/6098197/d8711320-2c16-463b-9d67-5bd9314acc7f)
+
+
+Or you've added them as a git submodule.
+
+![Screenshot-27](https://github.com/athackst/vscode_ros2_workspace/assets/6098197/8ebc9aac-9d70-4b53-aa52-9b5b108dc935)
+
+To add all of the repos in your *.repos file, run the script
+
+```bash
+python3 .devcontainer/repos_to_submodules.py
+```
+
+or run the task titled `add submodules from .repos`


### PR DESCRIPTION
There are two ways to see your repositories in the VS Code Source Control tab

1. You add them individually to the workspace, which looks like this

![Screenshot-26](https://github.com/athackst/vscode_ros2_workspace/assets/6098197/d8711320-2c16-463b-9d67-5bd9314acc7f)

2. You add them as a git submodule, which looks like this:

![Screenshot-27](https://github.com/athackst/vscode_ros2_workspace/assets/6098197/8ebc9aac-9d70-4b53-aa52-9b5b108dc935)

This script makes it easier to do (2)

Closes #56 