### PR TITLE
utilize nvidia gpu while running gazebo on linux and windows

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,21 @@
 FROM althack/ros2:humble-dev 
 
+### For Windows, uncomment the following lines to install WSLg dependencies and utilize vGPU acceleration 
+# ENV DEBIAN_FRONTEND=noninteractive
+# RUN apt-get update \
+#    && apt-get -y install \
+#           vainfo \
+#           mesa-va-drivers \
+#           mesa-utils \
+#    # Clean up
+#         && apt-get autoremove -y \
+#         && apt-get clean -y \
+#         && rm -rf /var/lib/apt/lists/*
+# ENV LIBVA_DRIVER_NAME=d3d12
+# ENV LD_LIBRARY_PATH=/usr/lib/wsl/lib
+# CMD vainfo --display drm --device /dev/dri/card0
+# ENV DEBIAN_FRONTEND=dialog
+
 # ** [Optional] Uncomment this section to install additional packages. **
 #
 # ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,8 +28,10 @@
 		"vscode": {
 			"extensions": [
 				"althack.ament-task-provider",
+				"betwo.b2-catkin-tools",
 				"DotJoshJohnson.xml",
 				"ms-azuretools.vscode-docker",
+				"ms-iot.vscode-ros",
 				"ms-python.python",
 				"ms-vscode.cpptools",
 				"redhat.vscode-yaml",
@@ -37,8 +39,7 @@
 				"streetsidesoftware.code-spell-checker",
 				"twxs.cmake",
 				"yzhang.markdown-all-in-one",
-				"zachflower.uncrustify",
-				"betwo.b2-catkin-tools"
+				"zachflower.uncrustify"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,7 @@
 	],
 	"containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}", // Needed for GUI try ":0" for windows
+		"WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
 		"XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
 		"PULSE_SERVER": "${localEnv:PULSE_SERVER}",
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,8 @@
 		"--volume=/tmp/.X11-unix:/tmp/.X11-unix",
 		"--volume=/mnt/wslg:/mnt/wslg",
 		"--ipc=host"
+		// uncomment to use intel iGPU
+		// "--device=/dev/dri"
 	],
 	"containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}", // Needed for GUI try ":0" for windows

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,6 @@
 	],
 	"containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}", // Needed for GUI try ":0" for windows
-		"WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
 		"XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
 		"PULSE_SERVER": "${localEnv:PULSE_SERVER}",
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 		"--security-opt=seccomp:unconfined",
 		"--security-opt=apparmor:unconfined",
 		"--volume=/tmp/.X11-unix:/tmp/.X11-unix",
-		"--volume=/mnt/wslg:/mnt/wslg"
+		"--volume=/mnt/wslg:/mnt/wslg",
+		"--ipc=host"
 	],
 	"containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}", // Needed for GUI try ":0" for windows

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,14 @@
 		"--ipc=host"
 		// uncomment to use intel iGPU
 		// "--device=/dev/dri"
+		// uncomment to use Nvidia GPU with Linux, https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+		// "--runtime=nvidia"
+		// uncomment to use Nvidia GPU with Windows WSL2
+		// "--volume=/usr/lib/wsl:/usr/lib/wsl",
+		// "--device=/dev/dxg",
+		// "--device=/dev/dri/card0",
+		// "--device=/dev/dri/renderD128",
+		// "--gpus=all"
 	],
 	"containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}", // Needed for GUI try ":0" for windows

--- a/.devcontainer/repos_to_submodules.py
+++ b/.devcontainer/repos_to_submodules.py
@@ -1,0 +1,38 @@
+import glob
+import os
+import subprocess
+import yaml
+
+prefix="src"
+
+def add_git_submodule(repo_name, repo_url, repo_version):
+    subprocess.call(['git', 'submodule', 'add', '-b', repo_version, repo_url, repo_name])
+
+def is_submodule(repo_name):
+    try:
+        subprocess.check_output(['git', 'submodule', 'status', repo_name], stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        return False 
+
+def parse_repos_file(file_path):
+    with open(file_path, 'r') as file:
+        repos_data = yaml.safe_load(file)
+        repositories = repos_data['repositories']
+        
+        for repo_name, repo_info in repositories.items():
+            if 'type' in repo_info and repo_info['type'] == 'git':
+                repo_url = repo_info['url']
+                repo_version = repo_info['version']
+                submodule_name = os.path.join(prefix, repo_name)
+
+                if not is_submodule(submodule_name):
+                    add_git_submodule(submodule_name, repo_url, repo_version)
+                    print(f"Added {repo_name} as a submodule.")
+
+# Find .repos files within the src directory
+repos_files = glob.glob('src/**/*.repos', recursive=True)
+
+# Process each .repos file
+for repos_file in repos_files:
+    parse_repos_file(repos_file)

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build and push docs
-        uses: athackst/mkdocs-simple-plugin@v2.3.0
+        uses: athackst/mkdocs-simple-plugin@v3.0.0

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build and push docs
-        uses: athackst/mkdocs-simple-plugin@v3.0.0
+        uses: athackst/mkdocs-simple-plugin@v3.1.0

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build and push docs
-        uses: athackst/mkdocs-simple-plugin@v2.2.0
+        uses: athackst/mkdocs-simple-plugin@v2.3.0

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build and push docs
         uses: athackst/mkdocs-simple-plugin@v3.1.0

--- a/.github/workflows/ros.yaml
+++ b/.github/workflows/ros.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - 
         name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Test
         uses: ./.github/actions/test/
@@ -32,7 +32,7 @@ jobs:
     steps:
       - 
         name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Run linter
         uses: ./.github/actions/lint/

--- a/.github/workflows/ros.yaml
+++ b/.github/workflows/ros.yaml
@@ -3,6 +3,11 @@ name: ROS
 on:
   pull_request:
   push:
+    branches: 
+      - foxy*
+      - humble*
+      - iron*
+      - main
   workflow_dispatch:
     
 jobs:
@@ -33,3 +38,13 @@ jobs:
         uses: ./.github/actions/lint/
         env: 
           LINTER: ${{ matrix.linter }}
+
+  complete:
+    name: Tests passed
+    needs:
+      - lint
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        run: echo "Completed successfully!"

--- a/.github/workflows/ros.yaml
+++ b/.github/workflows/ros.yaml
@@ -4,10 +4,9 @@ on:
   pull_request:
   push:
     branches: 
-      - foxy*
       - humble*
       - iron*
-      - main
+      - rolling*
   workflow_dispatch:
     
 jobs:

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -10,7 +10,7 @@
             "compilerPath": "/usr/bin/gcc",
             "compileCommands": "${workspaceFolder}/build/compile_commands.json",
             "cStandard": "c99",
-            "cppStandard": "c++14",
+            "cppStandard": "c++17",
             "intelliSenseMode": "linux-gcc-x64"
         }
     ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,7 +50,22 @@
           "ignoreFailures": true
         }
       ]
-    }
+    },
+    //Example of a ROS Launch file
+    {
+      "name": "ROS: Launch File (merge-install)",
+      "type": "ros",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "target": "${workspaceFolder}/install/share/${input:package}/launch/${input:ros_launch}",
+    },
+    {
+      "name": "ROS: Launch File (isolated-install)",
+      "type": "ros",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "target": "${workspaceFolder}/install/${input:package}/share/${input:package}/launch/${input:ros_launch}",
+    },
   ],
   "inputs": [
     {
@@ -64,6 +79,12 @@
       "type": "promptString",
       "description": "Program name",
       "default": "publisher_member_function"
+    },
+    {
+      "id": "ros_launch",
+      "type": "promptString",
+      "description": "ROS launch name",
+      "default": "file_name_launch.py"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -228,6 +228,13 @@
             "type": "shell",
             "command": "./setup.sh",
             "problemMatcher": []
+        },
+        {
+            "label": "add submodules from .repos",
+            "detail": "Create a git submodule for all repositories in your .repos file",
+            "type": "shell",
+            "command": "python3 .devcontainer/repos_to_submodules.py",
+            "problemMatcher": []
         }
     ],
     "inputs": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,7 +51,7 @@
             "label": "purge",
             "detail": "Purge workspace by deleting all generated files.",
             "type": "shell",
-            "command": "rm -fr build install log; py3clean .",
+            "command": "sudo rm -fr build install log; sudo py3clean .",
             "problemMatcher": []
         },
         // Linting and static code analysis tasks

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Take a look at [how I develop using tasks](https://www.allisonthackston.com/arti
 
 ### Debugging
 
-This template sets up debugging for python files and gdb for cpp programs.  See [`.vscode/launch.json`](.vscode/launch.json) for configuration details.
+This template sets up debugging for python files, gdb for cpp programs and ROS launch files.  See [`.vscode/launch.json`](.vscode/launch.json) for configuration details.
 
 ### Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -143,3 +143,26 @@ If you want to access the vGPU through WSL2, you'll need to add additional compo
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},
 ```
+
+### Repos are not showing up in VS Code source control
+
+This is likely because vscode doesn't necessarily know about other repositories unless you've added them directly. 
+
+```
+File->Add Folder To Workspace
+```
+
+![Screenshot-26](https://github.com/athackst/vscode_ros2_workspace/assets/6098197/d8711320-2c16-463b-9d67-5bd9314acc7f)
+
+
+Or you've added them as a git submodule.
+
+![Screenshot-27](https://github.com/athackst/vscode_ros2_workspace/assets/6098197/8ebc9aac-9d70-4b53-aa52-9b5b108dc935)
+
+To add all of the repos in your *.repos file, run the script
+
+```bash
+python3 .devcontainer/repos_to_submodules.py
+```
+
+or run the task titled `add submodules from .repos`

--- a/setup.sh
+++ b/setup.sh
@@ -3,5 +3,5 @@ set -e
 
 vcs import < src/ros2.repos src
 sudo apt-get update
-rosdep update
-rosdep install --from-paths src --ignore-src -y
+rosdep update --rosdistro=$ROS_DISTRO
+rosdep install --from-paths src --ignore-src -y --rosdistro=$ROS_DISTRO


### PR DESCRIPTION
Tried to run gazebo using althack/<ROS_VERSION>:<ROS_DISTRO>-gazebo-nvidia, it ran only on the CPU. 
To enable GPU usage instead of CPU on Windows WSL2 or Linux, uncommenting these lines is necessary. 
Additionally, ensuring that "LIBGL_ALWAYS_SOFTWARE" is set to "0" is also required.
If the robot model fails to show up in rviz2, `export LIBGL_ALWAYS_SOFTWARE=1`in the respective terminal before launching rviz2



