### PR TITLE
Add source script for ament tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,5 +70,6 @@
         ".vscode",
         ".vscode-insiders",
         ".devcontainer/devcontainer.json"
-    ]
+    ],
+    "ament-task-provider.envSetup": "source /opt/ros/humble/setup.bash",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -54,6 +54,13 @@
             "command": "sudo rm -fr build install log; sudo py3clean .",
             "problemMatcher": []
         },
+        {
+            "label": "source",
+            "detail": "Source workspace",
+            "type": "shell",
+            "command": "source /opt/ros/humble/setup.bash",
+            "problemMatcher": []
+        },
         // Linting and static code analysis tasks
         {
             "label": "fix",


### PR DESCRIPTION
Update to the [ROS2 ament task provider](https://marketplace.visualstudio.com/items?itemName=althack.ament-task-provider) extension (>=0.3.0) and set the command to source your environment in `.vscode/settings.json`

This change adds the following:

```jsonc
"ament-task-provider.envSetup": "source /opt/ros/humble/setup.bash",
```

Closes #71 #73 