### PR TITLE
Update to Jazzy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM althack/ros2:humble-dev 
+FROM althack/ros2:jazzy-dev
 
 # ** [Optional] Uncomment this section to install additional packages. **
 #

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-PYTHONPATH=src:install/lib/python3.10/site-packages
+PYTHONPATH=src:install/lib/python3.12/site-packages

--- a/.github/workflows/ros.yaml
+++ b/.github/workflows/ros.yaml
@@ -6,6 +6,7 @@ on:
     branches: 
       - humble*
       - iron*
+      - jazzy*
       - rolling*
   workflow_dispatch:
     

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/**",
-                "/opt/ros/humble/include/**"
+                "/opt/ros/jazzy/include/**"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,11 +9,11 @@
         "*.xacro": "xml"
     },
     "python.analysis.extraPaths": [
-        "/opt/ros/humble/lib/python3.10/site-packages/"
+        "/opt/ros/jazzy/lib/python3.12/site-packages/"
     ],
     // Autocomplete from ros python packages
     "python.autoComplete.extraPaths": [
-        "/opt/ros/humble/lib/python3.10/site-packages/"
+        "/opt/ros/jazzy/lib/python3.12/site-packages/"
     ],
     // Environment file lets vscode find python files within workspace
     "python.envFile": "${workspaceFolder}/.env",
@@ -24,7 +24,7 @@
     ],
     "C_Cpp.default.intelliSenseMode": "linux-gcc-x86",
     "C_Cpp.formatting": "disabled",
-    "uncrustify.configPath.linux": "/opt/ros/humble/lib/python3.10/site-packages/ament_uncrustify/configuration/ament_code_style.cfg",
+    "uncrustify.configPath.linux": "/opt/ros/jazzy/lib/python3.12/site-packages/ament_uncrustify/configuration/ament_code_style.cfg",
     "[cpp]": {
         "editor.defaultFormatter": "zachflower.uncrustify"
     },
@@ -71,5 +71,5 @@
         ".vscode-insiders",
         ".devcontainer/devcontainer.json"
     ],
-    "ament-task-provider.envSetup": "source /opt/ros/humble/setup.bash",
+    "ament-task-provider.envSetup": "source /opt/ros/jazzy/setup.bash",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -58,7 +58,7 @@
             "label": "source",
             "detail": "Source workspace",
             "type": "shell",
-            "command": "source /opt/ros/humble/setup.bash",
+            "command": "source /opt/ros/jazzy/setup.bash",
             "problemMatcher": []
         },
         // Linting and static code analysis tasks

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [how I develop with vscode and ros2](https://www.allisonthackston.com/articl
 ROS2-approved formatters are included in the IDE.  
 
 * **c++** uncrustify; config from `ament_uncrustify`
-* **python** autopep8; vscode settings consistent with the [style guide](https://docs.ros.org/en/humble/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html)
+* **python** autopep8; vscode settings consistent with the [style guide](https://docs.ros.org/en/jazzy/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html)
 
 ### Tasks
 
@@ -52,7 +52,7 @@ Click on "use this template"
 
 ### Create your repository
 
-On the next dialog, name the repository you would like to start and decide if you want all of the branches, or just the latest LTS: humble.
+On the next dialog, name the repository you would like to start and decide if you want all of the branches, or just the latest LTS: jazzy.
 
 ![template_new](https://user-images.githubusercontent.com/6098197/91332035-713ee980-e780-11ea-81d3-13b170f568b0.png)
 

--- a/src/ros2.repos
+++ b/src/ros2.repos
@@ -7,4 +7,4 @@ repositories:
   examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: humble
+    version: jazzy


### PR DESCRIPTION
The jazzy-dev image is [based off Ubuntu 24.04](https://github.com/athackst/dockerfiles/blob/9c7fbd67a5c7dbe041558ce10e3c9c1717b816f0/ros2/jazzy.Dockerfile#L8), which uses [python3.12](https://packages.ubuntu.com/noble/python3) (vs. humble / Ubuntu 22.04, which used [python3.10](https://packages.ubuntu.com/noble/python3)).